### PR TITLE
(fix) Detect out of sync pacman

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,10 @@ description = ""
 readme = "README.md"
 packages = [{include = "yay.py"}]
 maintainers = ["Alec Millis <theoxson@gmail.com>"]
-authors = ["Alec Millis <theoxson@gmail.com>", "Bjørn Snoen <bjorn.snoen@gmail.com>"]
+authors = [
+    "Alec Millis <theoxson@gmail.com>",
+    "Bjørn Polat-Snoen <bjorn.snoen@gmail.com>"
+]
 
 [tool.poetry.dependencies]
 python = "^3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "dotbot-yay"
+version = "1.0.1"
+description = ""
+readme = "README.md"
+packages = [{include = "yay.py"}]
+maintainers = ["Alec Millis <theoxson@gmail.com>"]
+authors = ["Alec Millis <theoxson@gmail.com>", "Bjørn Snoen <bjorn.snoen@gmail.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.6"
+
+
+[tool.poetry.group.dev.dependencies]
+dotbot = "^1.19.0"

--- a/yay.py
+++ b/yay.py
@@ -1,25 +1,35 @@
-import os, subprocess, dotbot, time
+import subprocess
+import time
+from collections import OrderedDict
 from enum import Enum
+
+import dotbot
+
 
 class PkgStatus(Enum):
     # These names will be displayed
-    UP_TO_DATE = 'Up to date'
-    INSTALLED= 'Installed'
-    UPDATED = 'Updated'
-    NOT_FOUND = 'Not Found'
+    UP_TO_DATE = "Up to date"
+    INSTALLED = "Installed"
+    UPDATED = "Updated"
+    NOT_FOUND = "Not Found"
+    PACMAN_ERROR = "Pacman error, make sure pacman dbs are synced by running pacman -Sy"
     ERROR = "Error"
-    NOT_SURE = 'Could not determine'
+    NOT_SURE = "Could not determine"
+
 
 class Yay(dotbot.Plugin):
-    _directive = 'yay'
+    _directive = "yay"
 
     def __init__(self, context):
         super(Yay, self).__init__(self)
         self._context = context
-        self._strings = {}
+        self._strings = OrderedDict()
 
         # Names to search the query string for
         self._strings[PkgStatus.ERROR] = "aborting"
+        self._strings[
+            PkgStatus.PACMAN_ERROR
+        ] = "Errors occurred, no packages were upgraded"
         self._strings[PkgStatus.NOT_FOUND] = "Could not find all required packages"
         self._strings[PkgStatus.UPDATED] = "Net Upgrade Size:"
         self._strings[PkgStatus.INSTALLED] = "Total Installed Size:"
@@ -30,18 +40,17 @@ class Yay(dotbot.Plugin):
 
     def handle(self, directive, data):
         if directive != self._directive:
-            raise ValueError('Yay cannot handle directive %s' %
-                directive)
+            raise ValueError(f"Yay cannot handle directive {directive}")
         return self._process(data)
 
     def _process(self, packages):
-        defaults = self._context.defaults().get('yay', {})
+        defaults = self._context.defaults().get("yay", {})
         results = {}
         successful = [PkgStatus.UP_TO_DATE, PkgStatus.UPDATED, PkgStatus.INSTALLED]
 
         for pkg in packages:
             if isinstance(pkg, dict):
-                self._log.error('Incorrect format')
+                self._log.error("Incorrect format")
             elif isinstance(pkg, list):
                 # self._log.error('Incorrect format')
                 pass
@@ -50,39 +59,43 @@ class Yay(dotbot.Plugin):
             result = self._install(pkg)
             results[result] = results.get(result, 0) + 1
             if result not in successful:
-                self._log.error("Could not install package '{}'".format(pkg))
-
+                self._log.error(f"Could not install package '{pkg}'")
 
         if all([result in successful for result in results.keys()]):
-            self._log.info('\nAll packages installed successfully')
+            self._log.info("\nAll packages installed successfully")
             success = True
         else:
             success = False
 
         for status, amount in results.items():
             log = self._log.info if status in successful else self._log.error
-            log('{} {}'.format(amount, status.value))
+            log(f"{amount} {status.value}")
 
         return success
 
     def _install(self, pkg):
         # to have a unified string which we can query
         # we need to execute the command with LANG=en_US
-        cmd = 'LANG=en_US yay --needed --noconfirm -S {}'.format(pkg)
+        cmd = f"LANG=en_US yay --needed --noconfirm -S {pkg}"
 
-        self._log.info("Installing \"{}\". Please wait...".format(pkg))
+        self._log.info(f'Installing "{pkg}". Please wait...')
 
         # needed to avoid conflicts due to locking
         time.sleep(1)
 
-        proc = subprocess.Popen(cmd, shell=True,
-                stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        proc = subprocess.Popen(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+
+        assert proc.stdout is not None
         out = proc.stdout.read()
         proc.stdout.close()
+
+        self._log.debug(out.decode("utf-8"))
 
         for item in self._strings.keys():
             if out.decode("utf-8").find(self._strings[item]) >= 0:
                 return item
 
-        self._log.warning("Could not determine what happened with package {}".format(pkg))
+        self._log.warning(f"Could not determine what happened with package {pkg}")
         return PkgStatus.NOT_SURE


### PR DESCRIPTION
(fix) Use OrderedDict to make sure we find errors before successes
(chore) Format with black
(chore) Use fstrings instead of str.format
(dev) Add yay output to debug logs for verbose logging

If you ran this plugin with pacman db being outdated, the plugin would report that all packages installed successfully, as it finds the `Total installed size:` string in the output, as this appears before the command fails. I added an extra string to look for which finds a pacman failure, and I switched to using OrderedDict to make sure we find the error strings before the success strings.

Other than this I added a pyproject.toml which just has dotbot as a poetry dev dependency, to make it easier to develop, and I did some general maintenance by using `black` to format the code and by switching the string formats to using fstrings. This makes it so the plugin will only work on python >=3.6. If that version constraint is too harsh I can remove it again, however 3.6 is now 6 years old, and most distros including debian buster have at least python 3.7 out of the box.